### PR TITLE
Mention sales@vshn.ch on contact page

### DIFF
--- a/docs/modules/ROOT/pages/contact.adoc
+++ b/docs/modules/ROOT/pages/contact.adoc
@@ -2,7 +2,7 @@
 
 == Office hours
 
-09:00 until 18:00 Monday to Friday excluding public Holidays (Zurich)
+09:00 until 18:00 Monday to Friday excluding public holidays (Zurich)
 
 == E-Mail Support / Helpdesk
 
@@ -15,10 +15,11 @@ CH-8005 Zürich
 
 === E-Mail
 
-E-Mail: info@vshn.ch +
-Support E-Mail: support@vshn.ch
+General inquiries: info@vshn.ch +
+Sales: sales@vshn.ch +
+Support: support@vshn.ch
 
-NOTE: Please use support@vshn.ch for support requests. E-Mails to support@vshn.ch are tracked in our Ticket System and help us to improve response time and quality of service.
+NOTE: E-mails to support@vshn.ch are tracked in our Ticket System and help us to improve response time and quality of service. You can also use our https://control.vshn.net/[Customer Portal] to open a support ticket. If you're not a customer yet please use sales@vshn.ch to get in touch.
 
 == Emergency contact procedure outside office hours
 


### PR DESCRIPTION
Sales has announced recently that sales@vshn.ch should be used to create tickets related to sales support. These changes reflect the announcement aka the process change.

## Related: VSHN Website

We may want to mention all those possibilities to get in touch also on our Website (e.g. at [Contact > Location](https://vshn.ch/en/contact/). Or maybe add a link to this page of the Knowledge Base?