### PR TITLE
ISMS-631/VT-1072 Add Security Process

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -24,6 +24,8 @@
 
 * xref:monitoring_concept.adoc[Monitoring]
 
+* xref:security_vulnerability_process.adoc[Security and Vulnerability Process]
+
 * xref:cicd_concept.adoc[Continuous Delivery]
 
 * Puppet

--- a/docs/modules/ROOT/pages/changelog.adoc
+++ b/docs/modules/ROOT/pages/changelog.adoc
@@ -4,6 +4,11 @@
 // so that the most recent version always appears on top.
 
 [discrete]
+== 2020–11-19: Version 1.2.1
+
+* Added xref:security_vulnerability_process.adoc[Security And Vulnerability Process]
+
+[discrete]
 == 2020–05–13: Version 1.2
 
 * Added VSHN products and legal documents.

--- a/docs/modules/ROOT/pages/security_vulnerability_process.adoc
+++ b/docs/modules/ROOT/pages/security_vulnerability_process.adoc
@@ -1,0 +1,67 @@
+= Security and Vulnerability Handling Process
+
+Critical security vulnerabilities are announced on mailing lists from suppliers, on security newsletters, by MELANI, and by many other sources.
+This security advisories are analysed and if a vulnerability affects the system directly, the update is planned as soon as possible.
+
+Urgent upgrades are assessed and planned immediately and less urgent vulnerabilities are patched according to our xref:maintenance_process[maintenance process].
+
+== General
+
+Our xref:maintenance_process[maintenance process] ensures regular system updates (there are some exceptions on customer's systems which are maintained according to special agreements).
+We manage server systems based on Ubuntu and RedHat.
+These two big players usually provide updates rapidly.
+With this regular maintenance the known vulnerabilities are eliminated within one week.
+
+Internal security incidents are reported according our ISO27001 certified https://handbook.vshn.ch/hb/domain_ism_incidentmanagement.html[incident management process].
+
+Our https://handbook.vshn.ch/hb/role_responsibleops.html[Responsible Ops] engineers are supervising our monitoring dashboard during office hours according to our xref:monitoring_concept[monitoring concept].
+The Responsible Ops engineers are able to react quickly during office hours.
+
+Customers can report vulnerabilities to VSHN according their https://kb.vshn.ch/products/sla_en.html[Service Level Agreement].
+
+We regularly discuss security issues in our https://vshn.chat[vshn.chat] #security channel.
+
+== Security Process
+
+=== Office Hours
+
+Our standard procedure to handle security issues or vulnerabilities.
+
+. Someone (customer, employee, https://handbook.vshn.ch/hb/role_responsibleops.html[Responsible Ops], etc.) become alert of a vulnerability.
+. Ticket is created in https://control.vshn.net.
+. If it's a critical vulnerability it's announced in our chat and an instant task force starts discussing potential solution paths.
+. If an immediate action within 24h is required, the affected systems will be updated. Because of our flexible working philosophy there is always someone found who can handle the update.
+. Such maintenance work is announced via:
+.. https://status.vshn.net/
+.. https://status.appuio.ch/
+
+=== Outside Office Hours
+
+VSHN doesn't actively supervise vulnerability announcements outside office hours.
+
+Customers with a 24/7 contract who become aware of a critical vulnerability should...
+
+. xref:create_ticket[create a ticket] in https://control.vshn.net/tickets[control.vshn.net] with high priority selected
+. AND call our 24/7 on-call number.
+
+The on-call engineer will assess the issue and has the possibility to call 2nd level on-call engineers, if there is a bigger problem to tackle down.
+
+
+== Lists
+
+We're subscribed to the most important security announcement lists, such as:
+
+* OS
+** Ubuntu https://lists.ubuntu.com/mailman/listinfo/ubuntu-security-announce[ubuntu-security-announce] mailing list
+** Red Hat https://www.redhat.com/wapps/ugc/protected/notif.html[Errata Notifications]
+* Authorities
+** https://www.melani.admin.ch/melani/de/home/dokumentation/newsletter_inhalt/news-abonnieren-neu.html[NCSC/MELANI Newsletter]
+** https://twitter.com/GOVCERT_CH[GovCERT.ch Twitter account]
+** SWITCH-CERT https://securityblog.switch.ch/[Blog] and https://twitter.com/switchcert[Twitter]
+** https://www.cybercrimepolice.ch/[Cybercrimepolice (KAPO ZH)]
+* Software
+** https://preferences.atlassian.com/[Atlassian products tech alerts]
+
+=== Individual Customer's Needs
+
+If you as a customer has a specific need to monitor a certain software or security list, please approach us so we can work out a process to ensure this.


### PR DESCRIPTION
For our ISE 3402 report control 5.6.1 we want to document our
vulnerability process. This is highly related to our security process
ticket VT-1072 which we wanted to tackle down long time ago.

This commit adds the process as it is currently handled in our company.

Improvements of the process can now be documented and discussed here and
ensured with trainings of our employees later.