### PR TITLE
Fix link to maintenance process

### DIFF
--- a/docs/modules/ROOT/pages/security_vulnerability_process.adoc
+++ b/docs/modules/ROOT/pages/security_vulnerability_process.adoc
@@ -3,11 +3,11 @@
 Critical security vulnerabilities are announced on mailing lists from suppliers, on security newsletters, by MELANI, and by many other sources.
 This security advisories are analysed and if a vulnerability affects the system directly, the update is planned as soon as possible.
 
-Urgent upgrades are assessed and planned immediately and less urgent vulnerabilities are patched according to our xref:maintenance_process[maintenance process].
+Urgent upgrades are assessed and planned immediately and less urgent vulnerabilities are patched according to our xref:maintenance_process.adoc[maintenance process].
 
 == General
 
-Our xref:maintenance_process[maintenance process] ensures regular system updates (there are some exceptions on customer's systems which are maintained according to special agreements).
+Our xref:maintenance_process.adoc[maintenance process] ensures regular system updates (there are some exceptions on customer's systems which are maintained according to special agreements).
 We manage server systems based on Ubuntu and RedHat.
 These two big players usually provide updates rapidly.
 With this regular maintenance the known vulnerabilities are eliminated within one week.


### PR DESCRIPTION
The `.adoc` was forgotten therefore the link ended in an anchor of the
same site.
Fixed with this commit.